### PR TITLE
Deprecate app: redirect all traffic to blog post

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/*  https://blog.malachidaily.com/within-app-memorize-the-bible  301!


### PR DESCRIPTION
Add Netlify _redirects with a 301! catch-all forwarding every path on the app domain to the within-app-memorize-the-bible blog post.